### PR TITLE
Option to create multiple batches at once

### DIFF
--- a/spec/modules/batch_spec.rb
+++ b/spec/modules/batch_spec.rb
@@ -5,8 +5,8 @@ describe Sidekiq::Grouping::Batch do
 
   context 'adding' do
     it 'must enqueue unbatched worker' do
-       RegularWorker.perform_async('bar')
-       expect(RegularWorker).to have_enqueued_job('bar')
+      RegularWorker.perform_async('bar')
+      expect(RegularWorker).to have_enqueued_job('bar')
     end
 
     it 'must not enqueue batched worker' do
@@ -61,7 +61,7 @@ describe Sidekiq::Grouping::Batch do
   end
 
   context 'flushing' do
-    it 'must put wokrer to queue on flush' do
+    it 'must put worker to queue on flush' do
       batch = subject.new(BatchedSizeWorker.name, 'batched_size')
 
       expect(batch.could_flush?).to be_falsy
@@ -69,6 +69,16 @@ describe Sidekiq::Grouping::Batch do
       batch.flush
       expect(BatchedSizeWorker).to have_enqueued_job([["bar"], ["bar"], ["bar"]])
       expect(batch.size).to eq(7)
+    end
+
+    it 'must put all jobs to worker queue' do
+      batch = subject.new(BatchedAtOnceWorker.name, 'batched_at_once')
+
+      expect(batch.could_flush?).to be_falsy
+      7.times { BatchedAtOnceWorker.perform_async('bar') }
+      batch.flush
+      expect(BatchedAtOnceWorker).to have_enqueued_job(["bar"],["bar"],["bar"],["bar"],["bar"],["bar"])
+      expect(batch.size).to eq(6)
     end
   end
 

--- a/spec/support/test_workers.rb
+++ b/spec/support/test_workers.rb
@@ -40,3 +40,12 @@ class BatchedUniqueArgsWorker
   def perform(foo)
   end
 end
+
+class BatchedAtOnceWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :batched_at_once, batch_size: 3, batch_at_once: true
+
+  def perform(foo)
+  end
+end

--- a/spec/support/test_workers.rb
+++ b/spec/support/test_workers.rb
@@ -49,3 +49,12 @@ class BatchedAtOnceWorker
   def perform(foo)
   end
 end
+
+class BatchedAtOnceIntervalWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :batched_at_once_interval, batch_size: 3, batch_at_once: true, batch_flush_interval: 3600
+
+  def perform(foo)
+  end
+end


### PR DESCRIPTION
When sidekiq option batch_at_once is set to true and and there are more than x times the batch_size of jobs waiting, sidekiq-grouping will then create multiple batches at once. 

Example: 

batch_size: 100
Jobs waiting: 450

Poll interval comes in sidekiq-grouping will create 4 batches with 100 items each batch instead of creating 1 batch each time polling. 