### PR TITLE
Workaround for celluloid 0.17

### DIFF
--- a/lib/sidekiq/grouping/supervisor.rb
+++ b/lib/sidekiq/grouping/supervisor.rb
@@ -4,9 +4,16 @@ module Sidekiq
       class << self
         include Sidekiq::Grouping::Logging
 
+        if Celluloid::VERSION >= '0.17'
+        def run!
+          info 'Sidekiq::Grouping starts supervision'
+          Sidekiq::Grouping::Actor.supervise as: :sidekiq_grouping
+        end
+        else
         def run!
           info 'Sidekiq::Grouping starts supervision'
           Sidekiq::Grouping::Actor.supervise_as(:sidekiq_grouping)
+        end
         end
       end
     end


### PR DESCRIPTION
There's no possibility to use `require 'celluloid/backported'` because Sidekiq itself requires `'celluloid/current'` :(

https://github.com/celluloid/celluloid/wiki/DEPRECATION-WARNING