### PR TITLE
Don't try to link to the sidekiq manager, it's no longer celluloid

### DIFF
--- a/lib/sidekiq/grouping/actor.rb
+++ b/lib/sidekiq/grouping/actor.rb
@@ -29,10 +29,9 @@ module Sidekiq
       end
 
       def link_to_sidekiq_manager
-        Sidekiq::CLI.instance.launcher.manager.link(current_actor)
         start_polling
-      rescue NoMethodError
-        debug "Can't link #{self.class.name}. Sidekiq::Manager not running. Retrying in 5 seconds ..."
+      rescue
+        info "Can't link #{self.class.name}. Sidekiq::Manager not running. Retrying in 5 seconds ..."
         after(5) { link_to_sidekiq_manager }
       end
 

--- a/lib/sidekiq/grouping/version.rb
+++ b/lib/sidekiq/grouping/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module Grouping
-    VERSION = '1.0.2'
+    VERSION = '1.0.3'
   end
 end


### PR DESCRIPTION
It appears that with the Sidekiq 4.0 upgrade, celluloid was removed. This gem
functions correctly without linking to the sidekiq manager. I'm not sure what
other ramifications there are to this change. Please let me know if this is safe.

I've tested locally and see that it works correctly, flushing its batches as needed.