### PR TITLE
Fix grouping/delete functionality

### DIFF
--- a/lib/sidekiq/grouping/views/index.erb
+++ b/lib/sidekiq/grouping/views/index.erb
@@ -26,6 +26,7 @@
           <td><%= batch.next_execution_time || "&ndash;"%></td>
           <td>
             <form action="<%= "#{root_path}grouping/#{batch.name}/delete" %>" method="post">
+              <%= csrf_tag %>
               <input class="btn btn-danger btn-xs" type="submit" name="delete" value="Delete" data-confirm="Are you sure you want to delete this batch?" />
             </form>
           </td>

--- a/lib/sidekiq/grouping/web.rb
+++ b/lib/sidekiq/grouping/web.rb
@@ -1,6 +1,6 @@
 require 'sidekiq/web'
 
-module Sidetiq
+module Sidekiq
   module Grouping
     module Web
       VIEWS = File.expand_path('views', File.dirname(__FILE__))
@@ -11,8 +11,8 @@ module Sidetiq
           erb File.read(File.join(VIEWS, 'index.erb')), locals: {view_path: VIEWS}
         end
 
-        app.post "/grouping/:name/delete" do
-          worker_class, queue = Sidekiq::Grouping::Batch.extract_worker_klass_and_queue(params['name'])
+        app.post "/grouping/*/delete" do |name|
+          worker_class, queue = Sidekiq::Grouping::Batch.extract_worker_klass_and_queue(name)
           batch = Sidekiq::Grouping::Batch.new(worker_class, queue)
           batch.delete
           redirect "#{root_path}/grouping"
@@ -23,6 +23,6 @@ module Sidetiq
   end
 end
 
-Sidekiq::Web.register(Sidetiq::Grouping::Web)
+Sidekiq::Web.register(Sidekiq::Grouping::Web)
 Sidekiq::Web.tabs["Grouping"] = "grouping"
 

--- a/sidekiq-grouping.gemspec
+++ b/sidekiq-grouping.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activesupport"
   spec.add_development_dependency "timecop"
 
-  spec.add_dependency "sidekiq"
+  spec.add_dependency "sidekiq", ">= 3.4.2"
   spec.add_dependency "concurrent-ruby"
 end


### PR DESCRIPTION
Sidekiq added XSRF protection (or at least this style of it) in 3.4.2, which breaks the delete functionality of Sidekiq::Grouping::Web. I've also been having trouble with the named parameter in the delete route, so I slightly modified it to use a wildcard instead. Let me know if you'd any tweaks or changes! 

* Add csrf_tag to comply with Rack::Protection
* Named route parameter not matching, so use wildcard instead
* Rename weird Sidetiq reference