### PR TITLE
Fix ActiveSupport::Inflector usage

### DIFF
--- a/lib/sidekiq/grouping/batch.rb
+++ b/lib/sidekiq/grouping/batch.rb
@@ -125,7 +125,7 @@ module Sidekiq
 
         def extract_worker_klass_and_queue(name)
           klass, queue = name.split(':')
-          [klass.classify, queue]
+          [klass.camelize, queue]
         end
       end
     end

--- a/lib/sidekiq/grouping/middleware.rb
+++ b/lib/sidekiq/grouping/middleware.rb
@@ -2,7 +2,7 @@ module Sidekiq
   module Grouping
     class Middleware
       def call(worker_class, msg, queue, redis_pool = nil)
-        worker_class = worker_class.classify.constantize if worker_class.is_a?(String)
+        worker_class = worker_class.camelize.constantize if worker_class.is_a?(String)
         options = worker_class.get_sidekiq_options
 
         batch =

--- a/sidekiq-grouping.gemspec
+++ b/sidekiq-grouping.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "rspec-sidekiq"
-  spec.add_development_dependency "activesupport"
   spec.add_development_dependency "timecop"
 
   spec.add_dependency "sidekiq"
+  spec.add_dependency "activesupport"
   spec.add_dependency "concurrent-ruby"
 end


### PR DESCRIPTION
* Use .camelize instead of .classify (basically the same thing, but does
  not singularize terms)
* Make ActiveSupport a runtime dependency (which it most certainly is)
  instead of a development dependency