### PR TITLE
Default batch_flush_size to batch_size (if specified)

### DIFF
--- a/lib/sidekiq/grouping/batch.rb
+++ b/lib/sidekiq/grouping/batch.rb
@@ -31,7 +31,7 @@ module Sidekiq
 
       def pluck_size
         worker_class_options['batch_flush_size'] ||
-          Sidekiq::Grouping::Config.max_batch_size
+          chunk_size
       end
 
       def pluck
@@ -87,9 +87,7 @@ module Sidekiq
       private
 
       def could_flush_on_overflow?
-        return true if size >= Sidekiq::Grouping::Config.max_batch_size
-        worker_class_options['batch_flush_size'] &&
-          size >= worker_class_options['batch_flush_size']
+        size >= pluck_size
       end
 
       def could_flush_on_time?

--- a/lib/sidekiq/grouping/middleware.rb
+++ b/lib/sidekiq/grouping/middleware.rb
@@ -6,8 +6,9 @@ module Sidekiq
         options = worker_class.get_sidekiq_options
 
         batch =
-          options.keys.include?('batch_flush_size') ||
-          options.keys.include?('batch_flush_interval')
+          options.key?('batch_flush_size') ||
+          options.key?('batch_flush_interval') ||
+          options.key?('batch_size')
 
         passthrough =
           msg['args'] &&


### PR DESCRIPTION
I'm trying to think of a good reason why batch_flush_size shouldn't default to batch_size (if specified), but I can't. Maybe someone else has a different use case where this doesn't make sense? Here's a patch in the meantime. 