### PR TITLE
Fix grouping delete from Sidekiq Web

### DIFF
--- a/lib/sidekiq/grouping/web.rb
+++ b/lib/sidekiq/grouping/web.rb
@@ -11,11 +11,11 @@ module Sidekiq
           erb File.read(File.join(VIEWS, 'index.erb')), locals: {view_path: VIEWS}
         end
 
-        app.post "/grouping/*/delete" do |name|
-          worker_class, queue = Sidekiq::Grouping::Batch.extract_worker_klass_and_queue(name)
+        app.post "/grouping/:name/delete" do
+          worker_class, queue = Sidekiq::Grouping::Batch.extract_worker_klass_and_queue(params['name'])
           batch = Sidekiq::Grouping::Batch.new(worker_class, queue)
           batch.delete
-          redirect "#{root_path}/grouping"
+          redirect "#{root_path}grouping"
         end
       end
 
@@ -25,4 +25,3 @@ end
 
 Sidekiq::Web.register(Sidekiq::Grouping::Web)
 Sidekiq::Web.tabs["Grouping"] = "grouping"
-


### PR DESCRIPTION
Fixes https://github.com/gzigzigzeo/sidekiq-grouping/issues/28

This gets the delete grouping action from Sidekiq Web working on the latest version of Sidekiq. Also, the redirect after deletion would take you to `/jobs//grouping`, this fixes that as well.