### PR TITLE
Delay initialization until Rails is fully initialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ Useful for:
 *NOTE:* As of 1.0.6 works with Sidekiq 4.
 *NOTE:* As of 1.0.8 Locking is atomic (set nx/ex) and will no longer lead to batches that are permalocked and stuck
 
+## Installation
+
+Add this line to your application's Gemfile:
+
+    gem 'sidekiq-grouping'
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install sidekiq-grouping
+
+If you're using the gem outside of Rails, run Grouping when application is initialized:
+
+```ruby
+Sidekiq::Grouping.start! if Sidekiq.server?
+```
+
 ## Usage
 
 Create a worker:
@@ -194,20 +214,6 @@ RSpec.describe GroupedWorker, type: :worker do
 end
 
 ```
-
-## Installation
-
-Add this line to your application's Gemfile:
-
-    gem 'sidekiq-grouping'
-
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install sidekiq-grouping
 
 ## Contributing
 

--- a/lib/sidekiq/grouping.rb
+++ b/lib/sidekiq/grouping.rb
@@ -3,6 +3,7 @@ require "active_support/configurable"
 require "active_support/core_ext/numeric/time"
 require "sidekiq/grouping/version"
 require "concurrent"
+require "sidekiq/grouping/railtie" if defined?(Rails)
 
 module Sidekiq::Grouping
   autoload :Config, "sidekiq/grouping/config"
@@ -50,4 +51,3 @@ Sidekiq.configure_server do |config|
   end
 end
 
-Sidekiq::Grouping.start! if Sidekiq.server?

--- a/lib/sidekiq/grouping/railtie.rb
+++ b/lib/sidekiq/grouping/railtie.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  module Grouping
+    class Railtie < ::Rails::Railtie
+      config.after_initialize do
+        Sidekiq::Grouping.start! if Sidekiq.server?
+      end
+    end
+  end
+end


### PR DESCRIPTION
_Related to the Zeitwerk [issue](https://github.com/fxn/zeitwerk/issues/150) about occasional `NameError` inside Sidekiq_

In some cases _sidekiq-grouping_ starts before Rails is fully initialized and Zeitwerk initial loading is completed, which can cause situations when some classes are loaded inside the concurrent thread rather than in Zeitwerk. This PR moves gem initialization to the Railtie.