### PR TITLE
Small fix to delete a queue with a batch class with a namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.byebug_history
 *.gem
 *.rbc
 .bundle

--- a/lib/sidekiq/grouping/views/index.erb
+++ b/lib/sidekiq/grouping/views/index.erb
@@ -25,7 +25,7 @@
           <td><%= batch.last_execution_time || "&ndash;"%></td>
           <td><%= batch.next_execution_time || "&ndash;"%></td>
           <td>
-            <form action="<%= "#{root_path}grouping/#{batch.name}/delete" %>" method="post">
+            <form action="<%= "#{root_path}grouping/#{CGI.escape(batch.name)}/delete" %>" method="post">
               <%= csrf_tag %>
               <input class="btn btn-danger btn-xs" type="submit" name="delete" value="Delete" data-confirm="Are you sure you want to delete this batch?" />
             </form>

--- a/lib/sidekiq/grouping/web.rb
+++ b/lib/sidekiq/grouping/web.rb
@@ -12,7 +12,7 @@ module Sidekiq
         end
 
         app.post "/grouping/:name/delete" do
-          worker_class, queue = Sidekiq::Grouping::Batch.extract_worker_klass_and_queue(params['name'])
+          worker_class, queue = Sidekiq::Grouping::Batch.extract_worker_klass_and_queue(CGI.unescape(params['name']))
           batch = Sidekiq::Grouping::Batch.new(worker_class, queue)
           batch.delete
           redirect "#{root_path}grouping"

--- a/sidekiq-grouping.gemspec
+++ b/sidekiq-grouping.gemspec
@@ -18,13 +18,14 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler", ">= 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "rspec-sidekiq"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "appraisal"
+  spec.add_development_dependency "byebug"
 
   spec.add_dependency "activesupport"
   spec.add_dependency "sidekiq", ">= 3.4.2"

--- a/spec/modules/batch_spec.rb
+++ b/spec/modules/batch_spec.rb
@@ -15,6 +15,12 @@ describe Sidekiq::Grouping::Batch do
     end
 
     it 'must not enqueue batched worker' do
+      WithNameSpace::BatchedSizeWorker.perform_async('bar')
+      puts WithNameSpace::BatchedSizeWorker.name.inspect
+      expect_batch(WithNameSpace::BatchedSizeWorker, 'batched_size')
+   end
+
+    it 'must not enqueue batched worker' do
       BatchedIntervalWorker.perform_async('bar')
       expect_batch(BatchedIntervalWorker, 'batched_interval')
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ $LOAD_PATH << "." unless $LOAD_PATH.include?(".")
 
 require "rubygems"
 require "bundler/setup"
+require "byebug"
 require "timecop"
 require "simplecov"
 require "sidekiq"

--- a/spec/support/test_workers.rb
+++ b/spec/support/test_workers.rb
@@ -14,6 +14,17 @@ class BatchedSizeWorker
   end
 end
 
+module WithNameSpace
+  class BatchedSizeWorker
+    include Sidekiq::Worker
+  
+    sidekiq_options queue: :batched_size, batch_flush_size: 3, batch_size: 2
+  
+    def perform(foo)
+    end
+  end
+end
+
 class BatchedIntervalWorker
   include Sidekiq::Worker
 


### PR DESCRIPTION
Trying to delete a queue where the batch worker class has a namespace you get a **NotFound** error on the UI. 
This patch should fix.
