### PR TITLE
Fix redis deprecation warnings

### DIFF
--- a/lib/sidekiq/grouping.rb
+++ b/lib/sidekiq/grouping.rb
@@ -1,3 +1,4 @@
+require "active_support"
 require "active_support/core_ext/string"
 require "active_support/configurable"
 require "active_support/core_ext/numeric/time"

--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -13,10 +13,10 @@ module Sidekiq
 
       def push_msg(name, msg, remember_unique = false)
         redis do |conn|
-          conn.multi do
-            conn.sadd(ns('batches'), name)
-            conn.rpush(ns(name), msg)
-            conn.sadd(unique_messages_key(name), msg) if remember_unique
+          conn.multi do |pipeline|
+            pipeline.sadd(ns('batches'), name)
+            pipeline.rpush(ns(name), msg)
+            pipeline.sadd(unique_messages_key(name), msg) if remember_unique
           end
         end
       end


### PR DESCRIPTION
This fixes deprecation warnings, seen when running the specs in this gem or using it, that look like this:
```
Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.multi do
  redis.get("key")
end

should be replaced by

redis.multi do |pipeline|
  pipeline.get("key")
end

(called from /home/grey/code/sidekiq-grouping/lib/sidekiq/grouping/redis.rb:16:in `block in push_msg'}
```

Also: When I first tried to run the specs, I ran into an error that looked like https://github.com/rails/rails/issues/43851, so this adds a `require` line that fixes the error.