### PR TITLE
Fixes sidekiq deprecation

### DIFF
--- a/lib/sidekiq/grouping/config.rb
+++ b/lib/sidekiq/grouping/config.rb
@@ -2,7 +2,7 @@ module Sidekiq::Grouping::Config
   include ActiveSupport::Configurable
 
   def self.options
-    Sidekiq.options[:grouping] || Sidekiq.options["grouping"] || {} # sidekiq 5.x use symbol in keys
+    Sidekiq[:grouping] || Sidekiq["grouping"] || {} # sidekiq 5.x uses symbols
   end
 
   # Queue size overflow check polling interval


### PR DESCRIPTION
Latest sidekiq produces deprecation warnings with this gem. Simply removed `.options` from the calls in `config.rb` results in no deprecations, all tests pass, and the code seems to work. Interested to see how this fares on Travis testing with older Sidekiq versions.

```
2022-08-08T15:49:59.336Z pid=8664 tid=1ef0 INFO: Booting Sidekiq 6.5.3 with Sidekiq::RedisConnection::RedisAdapter options {}
2022-08-08T15:49:59.359Z pid=8664 tid=1ef0 WARN: `config.options[:key] = value` is deprecated, use `config[:key] = value`: ["/Users/vox/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/sidekiq-grouping-1.1.0/lib/sidekiq/grouping/config.rb:5:in `options'", "/Users/vox/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/sidekiq-grouping-1.1.0/lib/sidekiq/grouping/config.rb:10:in `block in <module:Config>'"]
2022-08-08T15:49:59.360Z pid=8664 tid=1ef0 WARN: `config.options[:key] = value` is deprecated, use `config[:key] = value`: ["/Users/vox/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/sidekiq-grouping-1.1.0/lib/sidekiq/grouping/config.rb:5:in `options'", "/Users/vox/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/sidekiq-grouping-1.1.0/lib/sidekiq/grouping/config.rb:15:in `block in <module:Config>'"]
2022-08-08T15:49:59.360Z pid=8664 tid=1ef0 WARN: `config.options[:key] = value` is deprecated, use `config[:key] = value`: ["/Users/vox/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/sidekiq-grouping-1.1.0/lib/sidekiq/grouping/config.rb:5:in `options'", "/Users/vox/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/sidekiq-grouping-1.1.0/lib/sidekiq/grouping/config.rb:20:in `block in <module:Config>'"]
2022-08-08T15:49:59.360Z pid=8664 tid=1ef0 WARN: `config.options[:key] = value` is deprecated, use `config[:key] = value`: ["/Users/vox/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/sidekiq-grouping-1.1.0/lib/sidekiq/grouping/config.rb:5:in `options'", "/Users/vox/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/sidekiq-grouping-1.1.0/lib/sidekiq/grouping/config.rb:25:in `block in <module:Config>'"]
2022-08-08T15:49:59.360Z pid=8664 tid=1ef0 INFO: [Sidekiq::Grouping] Started polling batches every 5 seconds
```