### PR TITLE
Optimized Lua script for Redis >= 6.2.0

### DIFF
--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -3,10 +3,9 @@ module Sidekiq
     class Redis
 
       PLUCK_SCRIPT = <<-SCRIPT
-        local pluck_values = redis.call('lrange', KEYS[1], 0, ARGV[1] - 1)
-        redis.call('ltrim', KEYS[1], ARGV[1], -1)
-        for k, v in pairs(pluck_values) do
-          redis.call('srem', KEYS[2], v)
+        local pluck_values = redis.call('lpop', KEYS[1], ARGV[1]) or {}
+        if #pluck_values > 0 then 
+          redis.call('srem', KEYS[2], unpack(pluck_values)) 
         end
         return pluck_values
       SCRIPT

--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -13,9 +13,9 @@ module Sidekiq
       def push_msg(name, msg, remember_unique = false)
         redis do |conn|
           conn.multi do |pipeline|
-            pipeline.sadd(ns("batches"), name)
+            pipeline.sadd?(ns("batches"), name)
             pipeline.rpush(ns(name), msg)
-            pipeline.sadd(unique_messages_key(name), msg) if remember_unique
+            pipeline.sadd?(unique_messages_key(name), msg) if remember_unique
           end
         end
       end

--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -4,8 +4,8 @@ module Sidekiq
 
       PLUCK_SCRIPT = <<-SCRIPT
         local pluck_values = redis.call('lpop', KEYS[1], ARGV[1]) or {}
-        if #pluck_values > 0 then 
-          redis.call('srem', KEYS[2], unpack(pluck_values)) 
+        if #pluck_values > 0 then
+          redis.call('srem', KEYS[2], unpack(pluck_values))
         end
         return pluck_values
       SCRIPT


### PR DESCRIPTION
The previous version of PLUCK_SCRIPT used the following Redis commands:
**LRANGE** --> Complexity: O(S+N)         where S: the distance of start offset from HEAD and N: number of elements in the specified range
**LTRIM**     --> Complexity: O(N)
**SREM** * N times    --> Complexity: O(1) * N = O(N) 

Number of commands used: 1 [ LRANGE ] + 1 [ LTRIM ] + N * 1 [ SREM ] = N + 2

Instead, the current version uses the following:
**LPOP** with _count_ parameter  --> Complexity: O(N)
**SREM** with _list of keys_ --> Complexity:  O(N)

Number of commands used: 1 [ LPOP ] + 1 [ SREM ]= 2