### PR TITLE
Choose pluck_script based on Redis version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,10 @@ jobs:
           bundler: 2
           ruby-version: ${{ matrix.ruby_version }}
 
+      # Fix "installation path is insecure". Followed https://github.com/rubygems/rubygems/issues/7983
+      - name: Change permissions
+        run: chmod -R o-w /opt/hostedtoolcache/Ruby/3.1.6/x64/lib/ruby/gems/3.1.0/gems
+
       # Appraisal doesn't support vendored install
       # See: https://github.com/thoughtbot/appraisal/issues/173
       #      https://github.com/thoughtbot/appraisal/pull/174

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,10 @@ Documentation:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
-RSpec/FilePath:
+RSpec/SpecFilePathFormat:
+  Enabled: false
+
+RSpec/SpecFilePathSuffix:
   Enabled: false
 
 RSpec/ExampleLength:

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,16 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sidekiq-grouping.gemspec
 gemspec
+
+group :development do
+  gem 'appraisal'
+  gem 'bundler', '> 1.5'
+  gem 'pry'
+  gem 'rake'
+  gem 'rspec'
+  gem 'rspec-sidekiq'
+  gem 'rubocop'
+  gem 'rubocop-rspec'
+  gem 'simplecov'
+  gem 'timecop'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,14 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'appraisal'
-  gem 'bundler', '> 1.5'
-  gem 'pry'
-  gem 'rake'
-  gem 'rspec'
-  gem 'rspec-sidekiq'
-  gem 'rubocop'
-  gem 'rubocop-rspec'
-  gem 'simplecov'
-  gem 'timecop'
+  gem "appraisal"
+  gem "bundler", "> 1.5"
+  gem "pry"
+  gem "rake"
+  gem "rspec"
+  gem "rspec-sidekiq"
+  gem "rubocop"
+  gem "rubocop-rspec"
+  gem "simplecov"
+  gem "timecop"
 end

--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -112,6 +112,11 @@ module Sidekiq
         "batching:#{key}"
       end
 
+      #
+      # Get Redis server version
+      #
+      # @return [String] Redis server version
+      #
       def server_version
         Sidekiq.redis do |conn|
           conn.info["redis_version"]
@@ -122,7 +127,7 @@ module Sidekiq
       # The optimized LUA SCRIPT works from Redis greater than or equal to 6.2.
       # Check Redis version in use and return the suitable PLUCK_SCRIPT
       #
-      # @return [<Type>] <description>
+      # @return [String] Lua Script
       #
       def pluck_script
         if Gem::Version.new(server_version) >= Gem::Version.new(BREAK_VERSION)

--- a/lib/sidekiq/grouping/redis.rb
+++ b/lib/sidekiq/grouping/redis.rb
@@ -1,16 +1,27 @@
 # frozen_string_literal: true
 
-require_relative "./redis_dispatcher"
+require_relative "redis_dispatcher"
 
 module Sidekiq
   module Grouping
     class Redis
       include RedisDispatcher
 
-      PLUCK_SCRIPT = <<-SCRIPT
+      BREAK_VERSION = "6.2.0"
+
+      PLUCK_SCRIPT_GTE_6_2_0 = <<-SCRIPT
         local pluck_values = redis.call('lpop', KEYS[1], ARGV[1]) or {}
         if #pluck_values > 0 then
           redis.call('srem', KEYS[2], unpack(pluck_values))
+        end
+        return pluck_values
+      SCRIPT
+
+      PLUCK_SCRIPT_LT_6_2_0 = <<-SCRIPT
+        local pluck_values = redis.call('lrange', KEYS[1], 0, ARGV[1] - 1)
+        redis.call('ltrim', KEYS[1], ARGV[1], -1)
+        for k, v in pairs(pluck_values) do
+          redis.call('srem', KEYS[2], v)
         end
         return pluck_values
       SCRIPT
@@ -50,7 +61,7 @@ module Sidekiq
         if new_redis_client?
           redis_call(
             :eval,
-            PLUCK_SCRIPT,
+            pluck_script,
             2,
             ns(name),
             unique_messages_key(name),
@@ -59,7 +70,7 @@ module Sidekiq
         else
           keys = [ns(name), unique_messages_key(name)]
           args = [limit]
-          redis_call(:eval, PLUCK_SCRIPT, keys, args)
+          redis_call(:eval, pluck_script, keys, args)
         end
       end
 
@@ -99,6 +110,26 @@ module Sidekiq
 
       def ns(key = nil)
         "batching:#{key}"
+      end
+
+      def server_version
+        Sidekiq.redis do |conn|
+          conn.info["redis_version"]
+        end
+      end
+
+      #
+      # The optimized LUA SCRIPT works from Redis greater than or equal to 6.2.
+      # Check Redis version in use and return the suitable PLUCK_SCRIPT
+      #
+      # @return [<Type>] <description>
+      #
+      def pluck_script
+        if Gem::Version.new(server_version) >= Gem::Version.new(BREAK_VERSION)
+          PLUCK_SCRIPT_GTE_6_2_0
+        else
+          PLUCK_SCRIPT_LT_6_2_0
+        end
       end
     end
   end

--- a/sidekiq-grouping.gemspec
+++ b/sidekiq-grouping.gemspec
@@ -21,17 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7.0"
 
-  spec.add_development_dependency "appraisal"
-  spec.add_development_dependency "bundler", "> 1.5"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "rspec-sidekiq"
-  spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "rubocop-rspec"
-  spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "timecop"
-
   spec.add_dependency "activesupport"
   spec.add_dependency "concurrent-ruby"
   spec.add_dependency "sidekiq", ">= 3.4.2"

--- a/spec/modules/redis_spec.rb
+++ b/spec/modules/redis_spec.rb
@@ -41,4 +41,26 @@ describe Sidekiq::Grouping::Redis do
       expect(redis_call(:smembers, unique_key)).to eq []
     end
   end
+
+  describe "#pluck_script" do
+    context "when Redis server version is" do
+      it ">= 6.2.0, selects the corresponding pluck script" do
+        allow_any_instance_of(described_class)
+          .to receive(:server_version)
+          .and_return("6.2.0")
+        expect(redis_service.send(:pluck_script)).to eq(
+          described_class::PLUCK_SCRIPT_GTE_6_2_0
+        )
+      end
+
+      it "< 6.2.0, selects the corresponding pluck script" do
+        allow_any_instance_of(described_class)
+          .to receive(:server_version)
+          .and_return("6.0.0")
+        expect(redis_service.send(:pluck_script)).to eq(
+          described_class::PLUCK_SCRIPT_LT_6_2_0
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Since the updated LUA script coming from [this PR](https://github.com/gzigzigzeo/sidekiq-grouping/pull/50) uses commands available from Redis >= 6.2.0, with the following PR we select the old or new LUA script based on the Redis version